### PR TITLE
Create XW user when authenticating lims247 user

### DIFF
--- a/api/src/main/java/org/phenotips/integration/lims247/Lims247AuthServiceImpl.java
+++ b/api/src/main/java/org/phenotips/integration/lims247/Lims247AuthServiceImpl.java
@@ -89,6 +89,9 @@ public class Lims247AuthServiceImpl extends XWikiLDAPAuthServiceImpl implements 
                 user = checkRemoteToken(token, username, pn, context);
             }
             if (user != null) {
+                // Create a local user, otherwise this user will lack rights to perform actions in the application
+                createUser(username, context);
+
                 storeUserInSession(new LimsAuthentication(token, user, pn), context);
                 setupContextForLims(context);
                 storeAccesMode(context);


### PR DESCRIPTION
If an XW user is not created, the user lacks rights within PT.